### PR TITLE
Feature: Strictly check `formState`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "args": [
+        "--recursive",
+        "-u",
+        "tdd",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/tests"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "name": "Mocha Tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "pwa-node"
+    }
+  ]
+}

--- a/docs/rules/destructuring-formstate.md
+++ b/docs/rules/destructuring-formstate.md
@@ -14,12 +14,21 @@ Examples of **incorrect** code for this rule:
 return <button disabled={!formState.isDirty || !formState.isValid} />;
 ```
 
+```js
+const formState = useFormState(); // ❌ should deconstruct the formState
+formState.isDirty; // ❌ subscription will be one render behind.
+```
+
 Examples of **correct** code for this rule:
 
 ```jsx
 // ✅ read all formState values to subscribe to changes
 const { isDirty, isValid } = formState;
 return <button disabled={!isDirty || !isValid} />;
+```
+
+```js
+const { isDirty } = useFormState(); // ✅
 ```
 
 ### Options
@@ -32,4 +41,5 @@ If your app is **always** running on the platform which doesn't support Proxy su
 
 ## Further Reading
 
-[Document of React-Hook-Form - formState](https://react-hook-form.com/api/useform/formstate)
+[Document of React-Hook-Form - `formState`](https://react-hook-form.com/api/useform/formstate)
+[Document of React-Hook-Form - `useFormState`](https://react-hook-form.com/api/useformstate)

--- a/docs/rules/destructuring-formstate.md
+++ b/docs/rules/destructuring-formstate.md
@@ -1,10 +1,10 @@
-# Use desturcturing assignment to access the properties of formState. (destructuring-formstate)
+# Use destructuring assignment to access the properties of formState. (destructuring-formstate)
 
-This ensure the hook has subscribed to the changes of the states.
+This ensures the hook has subscribed to the changes of the states.
 
 ## Rule Details
 
-Since the `formState` is wrapped with a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to improve the render performance, it requires to `get` `fomrState`'s properties in the first render. So the component can aware of the state change and renders correctly. We suggest to use destructoring assignment to make sure the state has been subscribed.
+Since the `formState` is wrapped with a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to improve the render performance, it requires to `get` `fomrState`'s properties in the first render. So the component can aware of the state change and renders correctly. We suggest using destructuring assignment to make sure the state has been subscribed.
 
 Examples of **incorrect** code for this rule:
 

--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -15,7 +15,7 @@ module.exports = {
       description:
         "Use desturcturing assignment to access the properties of formState. This ensure the hook has subscribed to the changes of the states.",
       category: "Possible Errors",
-      url: "https://react-hook-form.com/api/useform/formstate",
+      url: "https://github.com/andykao1213/eslint-plugin-react-hook-form/blob/main/docs/rules/destructuring-formstate.md",
     },
     messages: {
       useDestuctor: "Use desturctoring assignment for formState's properties.",

--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -27,11 +27,25 @@ module.exports = {
     // Helpers
     //----------------------------------------------------------------------
 
-    function checkFormStateObject(node) {
-      if (node.object.name === "formState") {
-        return context.report({
-          node: node.property,
-          messageId: "useDestuctor",
+    function checkforUseForm(node) {
+      if (
+        node.init.type === "CallExpression" &&
+        node.init.callee.name === "useForm"
+      ) {
+        const formStateProperty = node.id.properties.find(
+          (p) => p.key.name === "formState"
+        );
+        if (formStateProperty?.value.type !== "Identifier") return;
+        const formStateName = formStateProperty.value.name;
+        const formStateVar = context.getScope().set.get(formStateName);
+        formStateVar.references.forEach((formStateReference) => {
+          const { parent } = formStateReference.identifier;
+          if (parent.type === "MemberExpression") {
+            return context.report({
+              node: parent.property,
+              messageId: "useDestuctor",
+            });
+          }
         });
       }
     }
@@ -41,7 +55,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     return {
-      MemberExpression: checkFormStateObject,
+      VariableDeclarator: checkforUseForm,
     };
   },
 };

--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -27,7 +27,20 @@ module.exports = {
     // Helpers
     //----------------------------------------------------------------------
 
-    function checkforUseForm(node) {
+    function checkIsAccessFormStateProperties(formStateName) {
+      const formStateVar = context.getScope().set.get(formStateName);
+      formStateVar.references.forEach((formStateReference) => {
+        const { parent } = formStateReference.identifier;
+        if (parent.type === "MemberExpression") {
+          return context.report({
+            node: parent.property,
+            messageId: "useDestuctor",
+          });
+        }
+      });
+    }
+
+    function check(node) {
       if (
         node.init.type === "CallExpression" &&
         node.init.callee.name === "useForm"
@@ -35,18 +48,15 @@ module.exports = {
         const formStateProperty = node.id.properties.find(
           (p) => p.key.name === "formState"
         );
+        // Only looking for {formState} or {formState: alias}
         if (formStateProperty?.value.type !== "Identifier") return;
-        const formStateName = formStateProperty.value.name;
-        const formStateVar = context.getScope().set.get(formStateName);
-        formStateVar.references.forEach((formStateReference) => {
-          const { parent } = formStateReference.identifier;
-          if (parent.type === "MemberExpression") {
-            return context.report({
-              node: parent.property,
-              messageId: "useDestuctor",
-            });
-          }
-        });
+        checkIsAccessFormStateProperties(formStateProperty.value.name);
+      } else if (
+        node.init.type === "CallExpression" &&
+        node.init.callee.name === "useFormState" &&
+        node.id.type === "Identifier"
+      ) {
+        checkIsAccessFormStateProperties(node.id.name);
       }
     }
 
@@ -55,7 +65,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     return {
-      VariableDeclarator: checkforUseForm,
+      VariableDeclarator: check,
     };
   },
 };

--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Use desturcturing assignment to access the properties of formState. This ensure the hook has subscribed to the changes of the states.
+ * @fileoverview Use destructuring assignment to access the properties of formState. This ensure the hook has subscribed to the changes of the states.
  * @author Andrew Kao
  */
 "use strict";
@@ -13,7 +13,7 @@ module.exports = {
     type: "problem",
     docs: {
       description:
-        "Use desturcturing assignment to access the properties of formState. This ensure the hook has subscribed to the changes of the states.",
+        "Use destructuring assignment to access the properties of formState. This ensure the hook has subscribed to the changes of the states.",
       category: "Possible Errors",
       url: "https://github.com/andykao1213/eslint-plugin-react-hook-form/blob/main/docs/rules/destructuring-formstate.md",
     },

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -11,44 +11,78 @@
 const rule = require("../../../lib/rules/destructuring-formstate"),
   RuleTester = require("eslint").RuleTester;
 
+const normalizeIndent = require("../utils/normalizeIndent");
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 ruleTester.run("destructuring-formstate", rule, {
   valid: [
     {
-      code: `
+      code: normalizeIndent`
         function Component() {
           const {formState: {isDirty}} = useForm();
           console.log(isDirty);
           return null;
         }
     `,
-      parserOptions: { ecmaVersion: 6 },
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const formState = {isDirty: true};
+          console.log(formState.isDirty);
+          return null;
+        }
+    `,
     },
   ],
 
   invalid: [
     {
-      code: `
+      code: normalizeIndent`
         function Component() {
-          const {formState: fs, register} = useForm();
-          console.log(fs.isDirty);
-          console.log(fs.errors);
+          const {formState, register} = useForm();
+          console.log(formState.isDirty);
+          console.log(formState.errors);
           return null;
         }
       `,
       errors: [
         {
           messageId: "useDestuctor",
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 32,
         },
         {
           messageId: "useDestuctor",
+          line: 5,
+          column: 25,
+          endLine: 5,
+          endColumn: 31,
         },
       ],
-      parserOptions: { ecmaVersion: 6 },
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {formState: fs, register} = useForm();
+          console.log(fs.isDirty);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestuctor",
+          line: 4,
+          column: 18,
+          endLine: 4,
+          endColumn: 25,
+        },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Use desturcturing assignment to access the properties of formState. This ensure the hook has subscribed to the changes of the states.
+ * @fileoverview Use destructuring assignment to access the properties of formState. This ensure the hook has subscribed to the changes of the states.
  * @author Andrew Kao
  */
 "use strict";

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -21,7 +21,7 @@ ruleTester.run("destructuring-formstate", rule, {
     {
       code: `
         function Component() {
-          const {formState: {isDirty}} = useFrom();
+          const {formState: {isDirty}} = useForm();
           console.log(isDirty);
           return null;
         }
@@ -34,12 +34,16 @@ ruleTester.run("destructuring-formstate", rule, {
     {
       code: `
         function Component() {
-          const {formState} = useFrom();
-          console.log(formState.isDirty);
+          const {formState: fs, register} = useForm();
+          console.log(fs.isDirty);
+          console.log(fs.errors);
           return null;
         }
       `,
       errors: [
+        {
+          messageId: "useDestuctor",
+        },
         {
           messageId: "useDestuctor",
         },

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -37,6 +37,15 @@ ruleTester.run("destructuring-formstate", rule, {
         }
     `,
     },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {isDirty} = useFormState();
+          console.log(isDirty);
+          return null;
+        }
+      `,
+    },
   ],
 
   invalid: [
@@ -81,6 +90,24 @@ ruleTester.run("destructuring-formstate", rule, {
           column: 18,
           endLine: 4,
           endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const formState = useFormState();
+          console.log(formState.isDirty);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestuctor",
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 32,
         },
       ],
     },

--- a/tests/lib/utils/normalizeIndent.js
+++ b/tests/lib/utils/normalizeIndent.js
@@ -1,0 +1,12 @@
+/**
+ * A string template tag that removes padding from the left side of multi-line strings.
+ * Reference: https://github.com/facebook/react/blob/master/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+ * @param {Array} strings array of code strings (only one expected)
+ */
+function normalizeIndent(strings) {
+  const codeLines = strings[0].split("\n");
+  const leftPadding = codeLines[1].match(/\s+/)[0];
+  return codeLines.map((line) => line.substr(leftPadding.length)).join("\n");
+}
+
+module.exports = normalizeIndent;


### PR DESCRIPTION
Add more conditions to the target variable `formState`:
* Check if the initializer is `useForm()`
* Check the alias. e.g. `{formState: fs}`
* Support `useFormState()`