### PR TITLE
fix: handle nullish `init` in `VariableDeclarator`

### DIFF
--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -42,8 +42,8 @@ module.exports = {
 
     function check(node) {
       if (
-        node.init.type === "CallExpression" &&
-        node.init.callee.name === "useForm"
+        node.init?.type === "CallExpression" &&
+        node.init?.callee.name === "useForm"
       ) {
         const formStateProperty = node.id.properties.find(
           (p) => p.key.name === "formState"
@@ -52,8 +52,8 @@ module.exports = {
         if (formStateProperty?.value.type !== "Identifier") return;
         checkIsAccessFormStateProperties(formStateProperty.value.name);
       } else if (
-        node.init.type === "CallExpression" &&
-        node.init.callee.name === "useFormState" &&
+        node.init?.type === "CallExpression" &&
+        node.init?.callee.name === "useFormState" &&
         node.id.type === "Identifier"
       ) {
         checkIsAccessFormStateProperties(node.id.name);

--- a/lib/rules/no-access-control.js
+++ b/lib/rules/no-access-control.js
@@ -29,8 +29,8 @@ module.exports = {
 
     function check(node) {
       if (
-        node.init.type === "CallExpression" &&
-        node.init.callee.name === "useForm"
+        node.init?.type === "CallExpression" &&
+        node.init?.callee.name === "useForm"
       ) {
         const controlProperty = node.id.properties.find(
           (p) => p.key.name === "control"

--- a/lib/rules/no-nested-object-setvalue.js
+++ b/lib/rules/no-nested-object-setvalue.js
@@ -42,8 +42,8 @@ module.exports = {
 
     function check(node) {
       if (
-        node.init.type === "CallExpression" &&
-        node.init.callee.name === "useForm"
+        node.init?.type === "CallExpression" &&
+        node.init?.callee.name === "useForm"
       ) {
         const setValueProperty = node.id.properties.find(
           (p) => p.key.name === "setValue"


### PR DESCRIPTION
`VariableDeclarator.init` will be `null` if this declarator isn't initialized. In particular, if the declarator hasn't been assigned by any value, the property `init` will be `null`. Thus, the pattern like `const a` will be failed.
We fix the issue by using ES6 optional chaining.

fix #11 