### PR TITLE
fix: handle different cases of the id of VariableDeclarator

### DIFF
--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const findPropertyByName = require("../utils/findPropertyByName");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -42,12 +44,11 @@ module.exports = {
 
     function check(node) {
       if (
+        node.type === "VariableDeclarator" &&
         node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useForm"
       ) {
-        const formStateProperty = node.id.properties.find(
-          (p) => p.key.name === "formState"
-        );
+        const formStateProperty = findPropertyByName(node, "formState");
         // Only looking for {formState} or {formState: alias}
         if (formStateProperty?.value.type !== "Identifier") return;
         checkIsAccessFormStateProperties(formStateProperty.value.name);

--- a/lib/rules/no-access-control.js
+++ b/lib/rules/no-access-control.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const findPropertyByName = require("../utils/findPropertyByName");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -29,12 +31,11 @@ module.exports = {
 
     function check(node) {
       if (
+        node.type === "VariableDeclarator" &&
         node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useForm"
       ) {
-        const controlProperty = node.id.properties.find(
-          (p) => p.key.name === "control"
-        );
+        const controlProperty = findPropertyByName(node, "control");
         // Only looking for {control} or {control: alias}
         if (controlProperty?.value.type !== "Identifier") return;
         const controlVar = context

--- a/lib/rules/no-nested-object-setvalue.js
+++ b/lib/rules/no-nested-object-setvalue.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const findPropertyByName = require("../utils/findPropertyByName");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -42,12 +44,11 @@ module.exports = {
 
     function check(node) {
       if (
+        node.type === "VariableDeclarator" &&
         node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useForm"
       ) {
-        const setValueProperty = node.id.properties.find(
-          (p) => p.key.name === "setValue"
-        );
+        const setValueProperty = findPropertyByName(node, "setValue");
         // Only looking for {setValue} or {setValue: alias}
         if (setValueProperty?.value.type !== "Identifier") return;
         const setValueVar = context

--- a/lib/utils/findPropertyByName.js
+++ b/lib/utils/findPropertyByName.js
@@ -1,0 +1,5 @@
+module.exports = function findPropertyByName(node, targetName) {
+  return node.id.type === "ObjectPattern"
+    ? node.id.properties.find((p) => p.key.name === targetName)
+    : null;
+};

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -16,7 +16,7 @@ const normalizeIndent = require("../utils/normalizeIndent");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 9 } });
 ruleTester.run("destructuring-formstate", rule, {
   valid: [
     {
@@ -43,6 +43,20 @@ ruleTester.run("destructuring-formstate", rule, {
           const {isDirty} = useFormState();
           console.log(isDirty);
           return null;
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const formMethods = useForm();
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {watch, ...restFormMethods} = useFormState();
         }
       `,
     },

--- a/tests/lib/rules/no-access-control.js
+++ b/tests/lib/rules/no-access-control.js
@@ -18,7 +18,7 @@ const normalizeIndent = require("../utils/normalizeIndent");
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 9,
     ecmaFeatures: {
       jsx: true,
     },
@@ -41,6 +41,20 @@ ruleTester.run("no-access-control", rule, {
             return <Controller control={c} />
         }
     `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const formMethods = useForm();
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {watch, ...restFormMethods} = useFormState();
+        }
+      `,
     },
   ],
   invalid: [

--- a/tests/lib/rules/no-nested-object-setvalue.js
+++ b/tests/lib/rules/no-nested-object-setvalue.js
@@ -18,7 +18,7 @@ const normalizeIndent = require("../utils/normalizeIndent");
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 9,
     ecmaFeatures: {
       jsx: true,
     },
@@ -36,6 +36,20 @@ ruleTester.run("no-nested-object-setvalue", rule, {
       code: normalizeIndent`
         const [value, setValue] = useState();
         setValue('yourDetails', { firstName: 'value' });
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const formMethods = useForm();
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {watch, ...restFormMethods} = useFormState();
+        }
       `,
     },
   ],


### PR DESCRIPTION
- `VariableDeclarator.id` may have different kinds of types. What we are interested in is the `ObjectPattern`. Add this condition to avoid errors in #13 and #14 . (Reference: https://github.com/estree/estree/blob/master/es2015.md#patterns)
- Upgrade the ecma version to `9` to support `RestElement` (References: https://github.com/estree/estree/blob/master/es2018.md#patterns)

fix: #13 #14 