### PR TITLE
docs: Fix typos

### DIFF
--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -15,12 +15,13 @@ module.exports = {
     type: "problem",
     docs: {
       description:
-        "Use destructuring assignment to access the properties of formState. This ensure the hook has subscribed to the changes of the states.",
+        "Use destructuring assignment to access the properties of formState. This ensures the hook has subscribed to the state changes.",
       category: "Possible Errors",
       url: "https://github.com/andykao1213/eslint-plugin-react-hook-form/blob/main/docs/rules/destructuring-formstate.md",
     },
     messages: {
-      useDestuctor: "Use desturctoring assignment for formState's properties.",
+      useDestructure:
+        "Use destructuring assignment for formState's properties.",
     },
   },
 
@@ -36,7 +37,7 @@ module.exports = {
         if (parent.type === "MemberExpression") {
           return context.report({
             node: parent.property,
-            messageId: "useDestuctor",
+            messageId: "useDestructure",
           });
         }
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "eslint-plugin-react-hook-form",
-      "version": "0.2.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "requireindex": "~1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.0",
+      "name": "eslint-plugin-react-hook-form",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "requireindex": "~1.1.0"

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -74,14 +74,14 @@ ruleTester.run("destructuring-formstate", rule, {
       `,
       errors: [
         {
-          messageId: "useDestuctor",
+          messageId: "useDestructure",
           line: 4,
           column: 25,
           endLine: 4,
           endColumn: 32,
         },
         {
-          messageId: "useDestuctor",
+          messageId: "useDestructure",
           line: 5,
           column: 25,
           endLine: 5,
@@ -99,7 +99,7 @@ ruleTester.run("destructuring-formstate", rule, {
       `,
       errors: [
         {
-          messageId: "useDestuctor",
+          messageId: "useDestructure",
           line: 4,
           column: 18,
           endLine: 4,
@@ -117,7 +117,7 @@ ruleTester.run("destructuring-formstate", rule, {
       `,
       errors: [
         {
-          messageId: "useDestuctor",
+          messageId: "useDestructure",
           line: 4,
           column: 25,
           endLine: 4,


### PR DESCRIPTION
Hi, thanks for this library. It would have saved me some [trouble](https://twitter.com/davidcrespo/status/1585309213303410688) if I knew about it yesterday. I noticed some typos in the error message, so this PR cleans them up. I don't think `useDestuctor` is user-facing, but I fixed that anyway.

![image](https://user-images.githubusercontent.com/3612203/198355784-b9f3d370-6b15-4364-a7ed-16663303c403.png)
