### PR TITLE
Check for aliased variables and method chains

### DIFF
--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -10,30 +10,34 @@ const findPropertyByName = require("../utils/findPropertyByName");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/** @type {import("eslint").Rule.RuleModule} */
 module.exports = {
   meta: {
     type: "problem",
     docs: {
       description:
-        "Use destructuring assignment to access the properties of formState. This ensures the hook has subscribed to the state changes.",
+        "Use destructuring assignment to access the properties of formState. This ensures the hook has subscribed to the state changes. Also checks for fieldState which internally reads formState.",
       category: "Possible Errors",
       url: "https://github.com/andykao1213/eslint-plugin-react-hook-form/blob/main/docs/rules/destructuring-formstate.md",
     },
     messages: {
       useDestructure:
-        "Use destructuring assignment for formState's properties.",
+        "Use destructuring assignment for formState's (or fieldState's) properties.",
     },
   },
 
-  create: function (context) {
+  create: function(context) {
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
 
-    function checkIsAccessFormStateProperties(formStateName) {
-      const formStateVar = context.getScope().set.get(formStateName);
-      formStateVar.references.forEach((formStateReference) => {
-        const { parent } = formStateReference.identifier;
+    /**
+     * @param {string} name
+     */
+    function checkIsAccessProperties(name) {
+      const variable = context.getScope().set.get(name);
+      variable.references.forEach((ref) => {
+        const { parent } = ref.identifier;
         if (parent.type === "MemberExpression") {
           return context.report({
             node: parent.property,
@@ -43,23 +47,38 @@ module.exports = {
       });
     }
 
+    /**
+     * @param {import("estree").Node} node
+     * @param {string} name
+     */
+    function checkIsAccessAssignedProperties(node, name) {
+      const property = findPropertyByName(node, name);
+      // Only looking for {formState} or {formState: alias}
+      if (property?.value.type === "Identifier") {
+        checkIsAccessProperties(property.value.name);
+      }
+    }
+
+    /** @param {import("estree").VariableDeclarator} node */
     function check(node) {
       if (
-        node.type === "VariableDeclarator" &&
         node.init?.type === "CallExpression" &&
         (node.init?.callee.name === "useForm" ||
           node.init?.callee.name === "useFormContext")
       ) {
-        const formStateProperty = findPropertyByName(node, "formState");
-        // Only looking for {formState} or {formState: alias}
-        if (formStateProperty?.value.type !== "Identifier") return;
-        checkIsAccessFormStateProperties(formStateProperty.value.name);
+        checkIsAccessAssignedProperties(node, "formState");
+      } else if (
+        node.init?.type === "CallExpression" &&
+        node.init?.callee.name === "useController"
+      ) {
+        checkIsAccessAssignedProperties(node, "formState");
+        checkIsAccessAssignedProperties(node, "fieldState");
       } else if (
         node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useFormState" &&
         node.id.type === "Identifier"
       ) {
-        checkIsAccessFormStateProperties(node.id.name);
+        checkIsAccessProperties(node.id.name);
       }
     }
 

--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -111,19 +111,15 @@ module.exports = {
 
     /** @param {import("estree").VariableDeclarator} node */
     function checkHooks(node) {
+      if (node.init?.type !== "CallExpression") return
       if (
-        node.init?.type === "CallExpression" &&
-        (node.init?.callee.name === "useForm" ||
-          node.init?.callee.name === "useFormContext")
+        node.init?.callee.name === "useForm" ||
+        node.init?.callee.name === "useFormContext"
       ) {
         traverseAliasedVariables(node, node.id, checkIsAccessAssignedFormProperties);
-      } else if (
-        node.init?.type === "CallExpression" &&
-        node.init?.callee.name === "useController"
-      ) {
+      } else if (node.init?.callee.name === "useController") {
         traverseAliasedVariables(node, node.id, checkIsAccessAssignedControllerProperties);
       } else if (
-        node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useFormState" &&
         node.id.type === "Identifier"
       ) {

--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -35,10 +35,11 @@ module.exports = {
     /**
      * @param {import("estree").Node} scopeNode
      * @param {import("estree").Pattern} node
-     * @param {(scopeNode: import("estree").Node, node: import("estree").Pattern) => void} callback
+     * @param {(scopeNode: import("estree").Node, node: import("estree").Pattern) => void} assignmentCallback
+     * @param {(node: import("estree").Node) => void} referenceCallback
      */
-    function traverseAliasedVariables(scopeNode, node, callback) {
-      callback(scopeNode, node);
+    function traverseAliasedVariables(scopeNode, node, assignmentCallback, referenceCallback) {
+      assignmentCallback(scopeNode, node);
 
       // Only check for aliasing (`const foo = bar`), not destructuring
       if (node.type === "Identifier") {
@@ -50,9 +51,22 @@ module.exports = {
           /** @type {import("estree").Node} */
           const parent = ref.identifier.parent;
           if (parent.type === "VariableDeclarator") {
-            traverseAliasedVariables(parent, parent.id, callback);
+            traverseAliasedVariables(parent, parent.id, assignmentCallback, referenceCallback);
           }
+          referenceCallback(parent);
         }
+      }
+    }
+
+    /**
+     * @param {import("estree").MemberExpression} node
+     */
+    function checkHasMemberAccess(node) {
+      if (node.type === "MemberExpression") {
+        context.report({
+          node: node.property,
+          messageId: "useDestructure",
+        });
       }
     }
 
@@ -64,13 +78,7 @@ module.exports = {
       // We can use context.sourceCode.getScope(node).set.get(name) in ESLint v8.37.0 or newer.
       const variable = context.getDeclaredVariables(scopeNode).find(v => v.name == name);
       variable.references.forEach((ref) => {
-        const { parent } = ref.identifier;
-        if (parent.type === "MemberExpression") {
-          return context.report({
-            node: parent.property,
-            messageId: "useDestructure",
-          });
-        }
+        checkHasMemberAccess(ref.identifier.parent);
       });
     }
 
@@ -104,9 +112,16 @@ module.exports = {
       checkIsAccessAssignedProperties(scopeNode, node, "fieldState");
     }
 
+    function checkIsMemberAccessFormProperties(node) {
+      if (node.type === 'MemberExpression' && node.property.type === 'Identifier' && (node.property.name === 'formState')) {
+        checkHasMemberAccess(node.parent);
+      }
+    }
 
-    function checkIsAccessPropertiesByIdentifier(scopeNode, identifier) {
-      checkIsAccessProperties(scopeNode, identifier.name);
+    function checkIsMemberAccessControllerProperties(node) {
+      if (node.type === 'MemberExpression' && node.property.type === 'Identifier' && (node.property.name === 'formState')) {
+        checkHasMemberAccess(node.parent);
+      }
     }
 
     /** @param {import("estree").VariableDeclarator} node */
@@ -116,14 +131,14 @@ module.exports = {
         node.init?.callee.name === "useForm" ||
         node.init?.callee.name === "useFormContext"
       ) {
-        traverseAliasedVariables(node, node.id, checkIsAccessAssignedFormProperties);
+        traverseAliasedVariables(node, node.id, checkIsAccessAssignedFormProperties, checkIsMemberAccessFormProperties);
       } else if (node.init?.callee.name === "useController") {
-        traverseAliasedVariables(node, node.id, checkIsAccessAssignedControllerProperties);
+        traverseAliasedVariables(node, node.id, checkIsAccessAssignedControllerProperties, checkIsMemberAccessControllerProperties);
       } else if (
         node.init?.callee.name === "useFormState" &&
         node.id.type === "Identifier"
       ) {
-        traverseAliasedVariables(node, node.id, checkIsAccessPropertiesByIdentifier);
+        traverseAliasedVariables(node, node.id, () => { }, checkHasMemberAccess);
       }
     }
 
@@ -146,7 +161,7 @@ module.exports = {
       const renderArg = renderFunc.params[0];
       if (!renderArg) return;
 
-      traverseAliasedVariables(renderFunc, renderArg, checkIsAccessAssignedControllerProperties);
+      traverseAliasedVariables(renderFunc, renderArg, checkIsAccessAssignedControllerProperties, checkIsMemberAccessControllerProperties);
     }
 
     //----------------------------------------------------------------------

--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -4,6 +4,7 @@
  */
 "use strict";
 
+const findJSXAttributeByName = require("../utils/findJSXAttributeByName");
 const findPropertyByName = require("../utils/findPropertyByName");
 
 //------------------------------------------------------------------------------
@@ -32,10 +33,12 @@ module.exports = {
     //----------------------------------------------------------------------
 
     /**
+     * @param {import("estree").Node} scopeNode
      * @param {string} name
      */
-    function checkIsAccessProperties(name) {
-      const variable = context.getScope().set.get(name);
+    function checkIsAccessProperties(scopeNode, name) {
+      // We can use context.sourceCode.getScope(node).set.get(name) in ESLint v8.37.0 or newer.
+      const variable = context.getDeclaredVariables(scopeNode).find(v => v.name == name);
       variable.references.forEach((ref) => {
         const { parent } = ref.identifier;
         if (parent.type === "MemberExpression") {
@@ -48,38 +51,62 @@ module.exports = {
     }
 
     /**
-     * @param {import("estree").Node} node
+     * @param {import("estree").Node} scopeNode
+     * @param {import("estree").Pattern} node
      * @param {string} name
      */
-    function checkIsAccessAssignedProperties(node, name) {
+    function checkIsAccessAssignedProperties(scopeNode, node, name) {
       const property = findPropertyByName(node, name);
       // Only looking for {formState} or {formState: alias}
       if (property?.value.type === "Identifier") {
-        checkIsAccessProperties(property.value.name);
+        checkIsAccessProperties(scopeNode, property.value.name);
       }
     }
 
     /** @param {import("estree").VariableDeclarator} node */
-    function check(node) {
+    function checkHooks(node) {
       if (
         node.init?.type === "CallExpression" &&
         (node.init?.callee.name === "useForm" ||
           node.init?.callee.name === "useFormContext")
       ) {
-        checkIsAccessAssignedProperties(node, "formState");
+        checkIsAccessAssignedProperties(node, node.id, "formState");
       } else if (
         node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useController"
       ) {
-        checkIsAccessAssignedProperties(node, "formState");
-        checkIsAccessAssignedProperties(node, "fieldState");
+        checkIsAccessAssignedProperties(node, node.id, "formState");
+        checkIsAccessAssignedProperties(node, node.id, "fieldState");
       } else if (
         node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useFormState" &&
         node.id.type === "Identifier"
       ) {
-        checkIsAccessProperties(node.id.name);
+        checkIsAccessProperties(node, node.id.name);
       }
+    }
+
+    /** @param {import("estree-jsx").JSXOpeningElement} node */
+    function checkJSX(node) {
+      if (!(
+        node.type === "JSXOpeningElement" &&
+        node.name.name === "Controller"
+      )) return;
+
+      const renderAttr = findJSXAttributeByName(node, "render");
+
+      if (!(
+        renderAttr?.value.type === "JSXExpressionContainer" &&
+        (renderAttr?.value.expression.type === "ArrowFunctionExpression" ||
+          renderAttr?.value.expression.type === "FunctionExpression")
+      )) return
+
+      const renderFunc = renderAttr.value.expression;
+      const renderArg = renderFunc.params[0];
+      if (!renderArg) return;
+
+      checkIsAccessAssignedProperties(renderFunc, renderArg, "formState");
+      checkIsAccessAssignedProperties(renderFunc, renderArg, "fieldState");
     }
 
     //----------------------------------------------------------------------
@@ -87,7 +114,8 @@ module.exports = {
     //----------------------------------------------------------------------
 
     return {
-      VariableDeclarator: check,
+      VariableDeclarator: checkHooks,
+      JSXOpeningElement: checkJSX,
     };
   },
 };

--- a/lib/rules/destructuring-formstate.js
+++ b/lib/rules/destructuring-formstate.js
@@ -34,6 +34,30 @@ module.exports = {
 
     /**
      * @param {import("estree").Node} scopeNode
+     * @param {import("estree").Pattern} node
+     * @param {(scopeNode: import("estree").Node, node: import("estree").Pattern) => void} callback
+     */
+    function traverseAliasedVariables(scopeNode, node, callback) {
+      callback(scopeNode, node);
+
+      // Only check for aliasing (`const foo = bar`), not destructuring
+      if (node.type === "Identifier") {
+        // Traverse references in scope
+        // We can use context.sourceCode.getScope(node).set.get(name) in ESLint v8.37.0 or newer.
+        const variable = context.getDeclaredVariables(scopeNode).find(v => v.name == node.name);
+        for (const ref of variable.references) {
+          if (ref.identifier === node) continue;
+          /** @type {import("estree").Node} */
+          const parent = ref.identifier.parent;
+          if (parent.type === "VariableDeclarator") {
+            traverseAliasedVariables(parent, parent.id, callback);
+          }
+        }
+      }
+    }
+
+    /**
+     * @param {import("estree").Node} scopeNode
      * @param {string} name
      */
     function checkIsAccessProperties(scopeNode, name) {
@@ -63,6 +87,28 @@ module.exports = {
       }
     }
 
+    /**
+     * @param {import("estree").Node} scopeNode
+     * @param {import("estree").Pattern} node
+     */
+    function checkIsAccessAssignedFormProperties(scopeNode, node) {
+      checkIsAccessAssignedProperties(scopeNode, node, "formState");
+    }
+
+    /**
+     * @param {import("estree").Node} scopeNode
+     * @param {import("estree").Pattern} node
+     */
+    function checkIsAccessAssignedControllerProperties(scopeNode, node) {
+      checkIsAccessAssignedProperties(scopeNode, node, "formState");
+      checkIsAccessAssignedProperties(scopeNode, node, "fieldState");
+    }
+
+
+    function checkIsAccessPropertiesByIdentifier(scopeNode, identifier) {
+      checkIsAccessProperties(scopeNode, identifier.name);
+    }
+
     /** @param {import("estree").VariableDeclarator} node */
     function checkHooks(node) {
       if (
@@ -70,19 +116,18 @@ module.exports = {
         (node.init?.callee.name === "useForm" ||
           node.init?.callee.name === "useFormContext")
       ) {
-        checkIsAccessAssignedProperties(node, node.id, "formState");
+        traverseAliasedVariables(node, node.id, checkIsAccessAssignedFormProperties);
       } else if (
         node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useController"
       ) {
-        checkIsAccessAssignedProperties(node, node.id, "formState");
-        checkIsAccessAssignedProperties(node, node.id, "fieldState");
+        traverseAliasedVariables(node, node.id, checkIsAccessAssignedControllerProperties);
       } else if (
         node.init?.type === "CallExpression" &&
         node.init?.callee.name === "useFormState" &&
         node.id.type === "Identifier"
       ) {
-        checkIsAccessProperties(node, node.id.name);
+        traverseAliasedVariables(node, node.id, checkIsAccessPropertiesByIdentifier);
       }
     }
 
@@ -105,8 +150,7 @@ module.exports = {
       const renderArg = renderFunc.params[0];
       if (!renderArg) return;
 
-      checkIsAccessAssignedProperties(renderFunc, renderArg, "formState");
-      checkIsAccessAssignedProperties(renderFunc, renderArg, "fieldState");
+      traverseAliasedVariables(renderFunc, renderArg, checkIsAccessAssignedControllerProperties);
     }
 
     //----------------------------------------------------------------------

--- a/lib/utils/findJSXAttributeByName.js
+++ b/lib/utils/findJSXAttributeByName.js
@@ -1,0 +1,8 @@
+/**
+ * @param {import("estree-jsx").JSXOpeningElement} node
+ * @param {string} name
+ * @returns {import("estree-jsx").JSXAttribute | null}
+ */
+module.exports = function findJSXAttributeByName(node, name) {
+  return node.attributes.find((p) => p.type === 'JSXAttribute' && p.name.name === name);
+};

--- a/lib/utils/findPropertyByName.js
+++ b/lib/utils/findPropertyByName.js
@@ -1,5 +1,6 @@
+/** @param {import("estree").Pattern} node */
 module.exports = function findPropertyByName(node, targetName) {
-  return node.id.type === "ObjectPattern"
-    ? node.id.properties.find((p) => p.key.name === targetName)
+  return node.type === "ObjectPattern"
+    ? node.properties.find((p) => p.key.name === targetName)
     : null;
 };

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -159,6 +159,65 @@ ruleTester.run("destructuring-formstate", rule, {
     {
       code: normalizeIndent`
         function Component() {
+          const form = useForm();
+          const {formState, register} = form;
+          console.log(formState.isDirty);
+          console.log(formState.errors);
+          if (foo) {
+            console.log(formState.isDirty);
+            for (const bar of baz) {
+              console.log(formState.isDirty);
+              class Foo {
+                bar() {
+                  console.log(formState.isDirty);
+                }
+              }
+            }
+          }
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 5,
+          column: 25,
+          endLine: 5,
+          endColumn: 32,
+        },
+        {
+          messageId: "useDestructure",
+          line: 6,
+          column: 25,
+          endLine: 6,
+          endColumn: 31,
+        },
+        {
+          messageId: "useDestructure",
+          line: 8,
+          column: 27,
+          endLine: 8,
+          endColumn: 34,
+        },
+        {
+          messageId: "useDestructure",
+          line: 10,
+          column: 29,
+          endLine: 10,
+          endColumn: 36,
+        },
+        {
+          messageId: "useDestructure",
+          line: 13,
+          column: 33,
+          endLine: 13,
+          endColumn: 40,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
           const {formState, fieldState} = useController();
           console.log(formState.isDirty);
           console.log(fieldState.isTouched);
@@ -205,6 +264,33 @@ ruleTester.run("destructuring-formstate", rule, {
           column: 19,
           endLine: 5,
           endColumn: 28,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const controller = useController();
+          const {formState, fieldState} = controller;
+          console.log(formState.isDirty);
+          console.log(fieldState.isTouched);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 5,
+          column: 25,
+          endLine: 5,
+          endColumn: 32,
+        },
+        {
+          messageId: "useDestructure",
+          line: 6,
+          column: 26,
+          endLine: 6,
+          endColumn: 35,
         },
       ],
     },
@@ -291,6 +377,36 @@ ruleTester.run("destructuring-formstate", rule, {
           line: 6,
           column: 53,
           endLine: 6,
+          endColumn: 62,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          return (
+            <Controller
+              render={controller => {
+                const {formState, fieldState} = controller;
+                return <span>{formState.isDirty}{fieldState.isTouched}</span>
+              }}
+            />
+          )
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 7,
+          column: 33,
+          endLine: 7,
+          endColumn: 40,
+        },
+        {
+          messageId: "useDestructure",
+          line: 7,
+          column: 53,
+          endLine: 7,
           endColumn: 62,
         },
       ],

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -218,6 +218,23 @@ ruleTester.run("destructuring-formstate", rule, {
     {
       code: normalizeIndent`
         function Component() {
+          const form = useForm();
+          console.log(form.formState.isDirty);
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 4,
+          column: 30,
+          endLine: 4,
+          endColumn: 37,
+        },
+      ]
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
           const {formState, fieldState} = useController();
           console.log(formState.isDirty);
           console.log(fieldState.isTouched);

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -31,8 +31,20 @@ ruleTester.run("destructuring-formstate", rule, {
     {
       code: normalizeIndent`
         function Component() {
+          const {formState: {isDirty}, fieldState: {isTouched}} = useController();
+          console.log(isDirty);
+          console.log(isTouched);
+          return null;
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
           const formState = {isDirty: true};
+          const fieldState = {isTouched: true};
           console.log(formState.isDirty);
+          console.log(fieldState.isTouched);
           return null;
         }
     `,
@@ -120,6 +132,58 @@ ruleTester.run("destructuring-formstate", rule, {
           column: 18,
           endLine: 4,
           endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {formState, fieldState} = useController();
+          console.log(formState.isDirty);
+          console.log(fieldState.isTouched);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 32,
+        },
+        {
+          messageId: "useDestructure",
+          line: 5,
+          column: 26,
+          endLine: 5,
+          endColumn: 35,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {formState: fs1, fieldState: fs2} = useController();
+          console.log(fs1.isDirty);
+          console.log(fs2.isTouched);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 4,
+          column: 19,
+          endLine: 4,
+          endColumn: 26,
+        },
+        {
+          messageId: "useDestructure",
+          line: 5,
+          column: 19,
+          endLine: 5,
+          endColumn: 28,
         },
       ],
     },

--- a/tests/lib/rules/destructuring-formstate.js
+++ b/tests/lib/rules/destructuring-formstate.js
@@ -16,7 +16,14 @@ const normalizeIndent = require("../utils/normalizeIndent");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 9 } });
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 9,
+    ecmaFeatures: {
+      jsx: true
+    },
+  },
+});
 ruleTester.run("destructuring-formstate", rule, {
   valid: [
     {
@@ -85,6 +92,20 @@ ruleTester.run("destructuring-formstate", rule, {
       code: normalizeIndent`
         function Component() {
           const formMethods = useFormContext();
+        }
+      `,
+    },
+    {
+      // We do not examine the object being spread, but at least it should not cause an error.
+      code: normalizeIndent`
+        function Component() {
+          return (
+            <Controller
+              {...{render: ({formState, fieldState}) => (
+                <span>{formState.isDirty}{fieldState.isTouched}</span>
+              )}}
+            />
+          )
         }
       `,
     },
@@ -184,6 +205,93 @@ ruleTester.run("destructuring-formstate", rule, {
           column: 19,
           endLine: 5,
           endColumn: 28,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          return (
+            <Controller
+              render={({formState, fieldState}) => (
+                <span>{formState.isDirty}{fieldState.isTouched}</span>
+              )}
+            />
+          )
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 6,
+          column: 26,
+          endLine: 6,
+          endColumn: 33,
+        },
+        {
+          messageId: "useDestructure",
+          line: 6,
+          column: 46,
+          endLine: 6,
+          endColumn: 55,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          return (
+            <Controller
+              render={({formState: fs1, fieldState: fs2}) => (
+                <span>{fs1.isDirty}{fs2.isTouched}</span>
+              )}
+            />
+          )
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 6,
+          column: 20,
+          endLine: 6,
+          endColumn: 27,
+        },
+        {
+          messageId: "useDestructure",
+          line: 6,
+          column: 33,
+          endLine: 6,
+          endColumn: 42,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          return (
+            <Controller
+              render={function({formState, fieldState}) {
+                return <span>{formState.isDirty}{fieldState.isTouched}</span>
+              }}
+            />
+          )
+        }
+      `,
+      errors: [
+        {
+          messageId: "useDestructure",
+          line: 6,
+          column: 33,
+          endLine: 6,
+          endColumn: 40,
+        },
+        {
+          messageId: "useDestructure",
+          line: 6,
+          column: 53,
+          endLine: 6,
+          endColumn: 62,
         },
       ],
     },


### PR DESCRIPTION
(rebase after #23)

For `<FormProvider {...form}>`, we assign like `const form = useForm()`. So this PR covers situations below:

- `const { formState } = form; formState.isValid`
- `form.formState.isValid`
