### PR TITLE
feat(no-use-watch): Add rule prohibiting use of watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ or start with the recommended rule set:
 | [destructuring-formstate](docs/rules/destructuring-formstate.md)     | Use destructuring assignment to access the properties of `formState`. | ⛔️         |         |
 | [no-access-control](docs/rules/no-access-control.md)                 | Avoid accessing the properties of `control`                           | ⛔️         |         |
 | [no-nested-object-setvalue](docs/rules/no-nested-object-setvalue.md) | Avoid nested object in second argument of `setValue`                  | ⛔️         | 🔧      |
+| [no-use-watch](docs/rules/no-use-watch.md)                           | Avoid using `watch`                                                   |             |         |
 
 ### Key
 

--- a/docs/rules/no-use-watch.md
+++ b/docs/rules/no-use-watch.md
@@ -1,0 +1,45 @@
+# Not use watch method. (no-use-watch)
+
+This ensures the hook has subscribed to the changes of the states when you use React Compiler.
+
+## Rule Details
+
+Since using useMemo with `watch` will cause results to be stale when you use React Compiler. This is part of a pattern, where non-hook APIs should always be memoizable.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+// ❌ should not use watch.
+const { watch } = useForm();
+```
+
+```jsx
+// ❌ should not use watch.
+const { watch } = useFormContext();
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+// ✅ Use useWatch instead of watch
+const { control } = useForm();
+const watchedValues = useWatch({ control });
+```
+
+```jsx
+// ✅ Use useWatch instead of watch
+const { control } = useFormContext();
+const watchedValues = useWatch({ control });
+```
+
+### Options
+
+NA
+
+## When Not To Use It
+
+NA
+
+## Further Reading
+
+[issue: Watch don't work with React Compiler (React 19) ](https://github.com/react-hook-form/react-hook-form/issues/11910)

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,13 +17,21 @@ var requireIndex = require("requireindex");
 // import all rules in lib/rules
 module.exports.rules = requireIndex(__dirname + "/rules");
 
+const plugins = ["react-hook-form"];
+
 module.exports.configs = {
   recommended: {
-    plugins: ["react-hook-form"],
+    plugins,
     rules: {
       "react-hook-form/destructuring-formstate": "error",
       "react-hook-form/no-access-control": "error",
       "react-hook-form/no-nested-object-setvalue": "error",
+    },
+    "react-compiler": {
+      plugins,
+      rules: {
+        "react-hook-form/no-use-watch": "error",
+      },
     },
   },
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,11 +27,11 @@ module.exports.configs = {
       "react-hook-form/no-access-control": "error",
       "react-hook-form/no-nested-object-setvalue": "error",
     },
-    "react-compiler": {
-      plugins,
-      rules: {
-        "react-hook-form/no-use-watch": "error",
-      },
+  },
+  "react-compiler": {
+    plugins,
+    rules: {
+      "react-hook-form/no-use-watch": "error",
     },
   },
 };

--- a/lib/rules/no-use-watch.js
+++ b/lib/rules/no-use-watch.js
@@ -29,7 +29,10 @@ module.exports = {
     // Helpers
     //----------------------------------------------------------------------
 
-    function check(node) {
+    // Store variables that were initialized with useForm or useFormContext
+    const formContextVars = new Set();
+
+    function checkCallExpression(node) {
       if (
         node.type === "VariableDeclarator" &&
         node.init?.type === "CallExpression" &&
@@ -37,6 +40,9 @@ module.exports = {
           node.init?.callee.name === "useFormContext")
       ) {
         if (node.id.type === "Identifier") {
+          // Add the variable to our tracking set
+          formContextVars.add(node.id.name);
+
           const formMethodsVar = context.getScope().set.get(node.id.name);
           formMethodsVar.references.forEach((formMethodsReference) => {
             const { parent } = formMethodsReference.identifier;
@@ -64,12 +70,33 @@ module.exports = {
       }
     }
 
+    function checkDestructuring(node) {
+      // Check for destructuring from a tracked form context variable
+      if (
+        node.type === "VariableDeclarator" &&
+        node.init?.type === "Identifier" &&
+        formContextVars.has(node.init.name) &&
+        node.id.type === "ObjectPattern"
+      ) {
+        const watchProperty = findPropertyByName(node, "watch");
+        if (watchProperty?.value.type === "Identifier") {
+          context.report({
+            node: watchProperty.value,
+            messageId: "useUseWatch",
+          });
+        }
+      }
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
 
     return {
-      VariableDeclarator: check,
+      VariableDeclarator(node) {
+        checkCallExpression(node);
+        checkDestructuring(node);
+      },
     };
   },
 };

--- a/lib/rules/no-use-watch.js
+++ b/lib/rules/no-use-watch.js
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview Use useWatch instead of watch. This ensures the hook has subscribed to the state changes when using React Compiler.
+ * @author tatsuya.asami
+ */
+"use strict";
+
+const findPropertyByName = require("../utils/findPropertyByName");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Use useWatch instead of watch. This ensures the hook has subscribed to the state changes when using React Compiler",
+      category: "Possible Errors",
+      url: "https://github.com/andykao1213/eslint-plugin-react-hook-form/blob/main/docs/rules/no-use-watch.md",
+    },
+    messages: {
+      useUseWatch: "Use useWatch instead of watch.",
+    },
+  },
+
+  create: function (context) {
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    function check(node) {
+      if (
+        node.type === "VariableDeclarator" &&
+        node.init?.type === "CallExpression" &&
+        (node.init?.callee.name === "useForm" ||
+          node.init?.callee.name === "useFormContext")
+      ) {
+        if (node.id.type === "Identifier") {
+          const formMethodsVar = context.getScope().set.get(node.id.name);
+          formMethodsVar.references.forEach((formMethodsReference) => {
+            const { parent } = formMethodsReference.identifier;
+
+            if (
+              parent.type === "MemberExpression" &&
+              parent.property.type === "Identifier" &&
+              parent.property.name === "watch"
+            ) {
+              context.report({
+                node: parent.property,
+                messageId: "useUseWatch",
+              });
+            }
+          });
+        } else {
+          const watchProperty = findPropertyByName(node, "watch");
+          // Only looking for {watch} or {watch: alias}
+          if (watchProperty?.value.type !== "Identifier") return;
+          return context.report({
+            node: watchProperty.value,
+            messageId: "useUseWatch",
+          });
+        }
+      }
+    }
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      VariableDeclarator: check,
+    };
+  },
+};

--- a/tests/lib/rules/no-use-watch.js
+++ b/tests/lib/rules/no-use-watch.js
@@ -23,7 +23,7 @@ ruleTester.run("no-use-watch", rule, {
       code: normalizeIndent`
         function Component() {
           const {control} = useForm();
-          uswWatch(control);
+          useWatch(control);
           return null;
         }
     `,
@@ -32,7 +32,7 @@ ruleTester.run("no-use-watch", rule, {
       code: normalizeIndent`
         function Component() {
           const {control} = useFormState();
-          uswWatch(control);
+          useWatch(control);
           return null;
         }
       `,

--- a/tests/lib/rules/no-use-watch.js
+++ b/tests/lib/rules/no-use-watch.js
@@ -119,5 +119,43 @@ ruleTester.run("no-use-watch", rule, {
         },
       ],
     },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const form = useForm();
+          const {watch} = form;
+          console.log(watch());
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useUseWatch",
+          line: 4,
+          column: 10,
+          endLine: 4,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const formContext = useFormContext();
+          const {watch} = formContext;
+          console.log(watch());
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useUseWatch",
+          line: 4,
+          column: 10,
+          endLine: 4,
+          endColumn: 15,
+        },
+      ],
+    },
   ],
 });

--- a/tests/lib/rules/no-use-watch.js
+++ b/tests/lib/rules/no-use-watch.js
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Use useWatch instead of watch. This ensures the hook has subscribed to the state changes when using React Compiler.
+ * @author tatsuya.asami
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-use-watch"),
+  RuleTester = require("eslint").RuleTester;
+
+const normalizeIndent = require("../utils/normalizeIndent");
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 9 } });
+ruleTester.run("no-use-watch", rule, {
+  valid: [
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {control} = useForm();
+          uswWatch(control);
+          return null;
+        }
+    `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {control} = useFormState();
+          uswWatch(control);
+          return null;
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const watch = 'watch';
+          console.log(watch);
+          return null;
+        }
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {watch} = useForm();
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useUseWatch",
+          line: 3,
+          column: 10,
+          endLine: 3,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const formMethods = useForm();
+          console.log(formMethods.watch());
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useUseWatch",
+          line: 4,
+          column: 27,
+          endLine: 4,
+          endColumn: 32,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {watch} = useFormContext();
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useUseWatch",
+          line: 3,
+          column: 10,
+          endLine: 3,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const formContext = useFormContext();
+          console.log(formContext.watch());
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "useUseWatch",
+          line: 4,
+          column: 27,
+          endLine: 4,
+          endColumn: 32,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
A new rule prohibiting the use of watch has been added.

Since there are cases where values are not updated when the React compiler and watch are used together, the use of watch is prohibited and useWatch should always be used.

https://github.com/react-hook-form/react-hook-form/issues/11910